### PR TITLE
Updated the path element env var name

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -6,5 +6,5 @@ for dir in logs tmp pid cache dbs env; do
 	mkdir -p $dir
 done
 
-echo $(pwd)/versions/2.6/bin > env/OPENSHIFT_RUBY_PATH_ELEMENT
+echo $(pwd)/versions/2.6/bin > env/OPENSHIFT_REDIS_PATH_ELEMENT
 cat /dev/urandom | head -c${1:-32} | sha256sum | base64 | head -c 30 > env/REDIS_PASSWORD


### PR DESCRIPTION
I'm not sure if this was a fluke or not, but it happened to me 3 times in a row: with `bin/setup` creating `env/OPENSHIFT_RUBY_PATH_ELEMENT` I was never able to start redis in a ruby-1.9 application.

I modified it to create `env/OPENSHIFT_REDIS_PATH_ELEMENT` instead, and now I can install and use Redis in a ruby-1.9 app.
