### PR TITLE
Cartridge won't start service after uncleanly stopped

### DIFF
--- a/bin/control
+++ b/bin/control
@@ -61,7 +61,10 @@ function update() {
 }
 
 function start() {
-    if ! [ -f $pid ]; then
+    if process_running 'redis-server', $pid; then
+        echo "Redis is running"
+        return 0
+    else
         echo $REDIS_CLI > env/REDIS_CLI
         erb conf/redis.conf.erb | redis-server -
 


### PR DESCRIPTION
This pull request is in response to issue #5 .
The OPENSHIFT_CARTRIDGE_SDK has a function (process_running) to control the status of a process.
